### PR TITLE
ci: Exclude non-workflow features from Gallery form changelog

### DIFF
--- a/.github/workflows/alfred-workflow-release.yml
+++ b/.github/workflows/alfred-workflow-release.yml
@@ -32,6 +32,7 @@ jobs:
             ref="$root_commit"
           fi
           changelog=$(git log "$ref"..HEAD^ --format='- %s' |
+            grep --extended-regexp --invert-match '^- (build|chore|ci|release)' |
             sed -E "s/^- ([^ ]+): /- **\1**: /" | tr " " "+") # `+` to encode spaces in url
 
           new_version=$(git tag --sort=-creatordate | head -n1)


### PR DESCRIPTION
## What problem does this PR solve?

Tidier change log for the submission for, by excluding things which aren’t relevant for users of the workflow.

## How does the PR solve it?

By excluding those lines before the final submission.

## Checklist
- [ ] Used only `camelCase` variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.
