### PR TITLE
feature: Adding next Monday capability

### DIFF
--- a/scripts/add-reminder.swift
+++ b/scripts/add-reminder.swift
@@ -106,8 +106,8 @@ eventStore.requestFullAccessToReminders { granted, error in
 	if dayOffset <= 2 {
 		targetDate = calendar.date(byAdding: .day, value: dayOffset, to: today)!
 	} else {
-		// only access this part only when dayOffset > 2
-		//	This is to ensure the compability with the existing capability
+		// Only access this part when dayOffset > 2
+		//	to ensure compability with the existing capability
 		// 1 = Sunday, 2 = Monday, ... 7 = Saturday
 		// .nextTime ensures it's the next Monday (not today, even if today is Monday)
 		targetDate = calendar.nextDate(
@@ -117,7 +117,7 @@ eventStore.requestFullAccessToReminders { granted, error in
 		)!
 	}
 
-	// Set due date components
+	// Set due date
 	var dateComponents = calendar.dateComponents([.year, .month, .day], from: targetDate)
 	if !isAllDayReminder {
 		dateComponents.hour = hh

--- a/scripts/add-reminder.swift
+++ b/scripts/add-reminder.swift
@@ -123,7 +123,6 @@ eventStore.requestFullAccessToReminders { granted, error in
 		dateComponents.hour = hh
 		dateComponents.minute = mm
 	}
-
 	reminder.dueDateComponents = dateComponents
 	reminder.startDateComponents = nil  // reminders created regularly have no start date, we mimic that
 

--- a/scripts/add-reminder.swift
+++ b/scripts/add-reminder.swift
@@ -101,30 +101,28 @@ eventStore.requestFullAccessToReminders { granted, error in
 
 	// determine day when to add
 	let calendar = Calendar.current
-   let today = Date()
-
-  	let targetDate: Date
-  	if dayOffset <= 2 {
-      targetDate = calendar.date(byAdding: .day, value: dayOffset, to: today)!
-  	} else {
+	let today = Date()
+	let targetDate: Date
+	if dayOffset <= 2 {
+		targetDate = calendar.date(byAdding: .day, value: dayOffset, to: today)!
+	} else {
 		// only access this part only when dayOffset > 2
-		// This is to ensure the compability with the existing capability
+		//	This is to ensure the compability with the existing capability
 		// 1 = Sunday, 2 = Monday, ... 7 = Saturday
-      // .nextTime ensures it's the next Monday (not today, even if today is Monday)
-      targetDate = calendar.nextDate(
-          after: today,
-          matching: DateComponents(weekday: 2),
-          matchingPolicy: .nextTime
-      )!
-  	}
+		// .nextTime ensures it's the next Monday (not today, even if today is Monday)
+		targetDate = calendar.nextDate(
+			after: today,
+			matching: DateComponents(weekday: 2),
+			matchingPolicy: .nextTime
+		)!
+	}
 
-  	// Set due date components
-  	var dateComponents = calendar.dateComponents([.year, .month, .day], from: targetDate)
-  	if !isAllDayReminder {
-   	   dateComponents.hour = hh
-      	dateComponents.minute = mm
-      	// dateComponents.second = 0 // optional
-  	}
+	// Set due date components
+	var dateComponents = calendar.dateComponents([.year, .month, .day], from: targetDate)
+	if !isAllDayReminder {
+		dateComponents.hour = hh
+		dateComponents.minute = mm
+	}
 
 	reminder.dueDateComponents = dateComponents
 	reminder.startDateComponents = nil  // reminders created regularly have no start date, we mimic that

--- a/scripts/add-reminder.swift
+++ b/scripts/add-reminder.swift
@@ -101,15 +101,31 @@ eventStore.requestFullAccessToReminders { granted, error in
 
 	// determine day when to add
 	let calendar = Calendar.current
-	let today = Date()
-	let dayToUse = calendar.date(byAdding: .day, value: dayOffset, to: today)!
+   let today = Date()
 
-	// Set due date
-	var dateComponents = calendar.dateComponents([.year, .month, .day], from: dayToUse)
-	if !isAllDayReminder {
-		dateComponents.hour = hh
-		dateComponents.minute = mm
-	}
+  	let targetDate: Date
+  	if dayOffset <= 2 {
+      targetDate = calendar.date(byAdding: .day, value: dayOffset, to: today)!
+  	} else {
+		// only access this part only when dayOffset > 2
+		// This is to ensure the compability with the existing capability
+		// 1 = Sunday, 2 = Monday, ... 7 = Saturday
+      // .nextTime ensures it's the next Monday (not today, even if today is Monday)
+      targetDate = calendar.nextDate(
+          after: today,
+          matching: DateComponents(weekday: 2),
+          matchingPolicy: .nextTime
+      )!
+  	}
+
+  	// Set due date components
+  	var dateComponents = calendar.dateComponents([.year, .month, .day], from: targetDate)
+  	if !isAllDayReminder {
+   	   dateComponents.hour = hh
+      	dateComponents.minute = mm
+      	// dateComponents.second = 0 // optional
+  	}
+
 	reminder.dueDateComponents = dateComponents
 	reminder.startDateComponents = nil  // reminders created regularly have no start date, we mimic that
 


### PR DESCRIPTION
## Problem Statement

The current add-reminder feature only supports today, +1 day, or +2 days. I often need to add a reminder for the following week, so the existing capability is insufficient. This PR proposes adding an _add-reminder-to-next-Monday_ option.

## Proposed Solution

The current flow uses the `dayToUse` variable to generate reminders. Instead of assigning it directly to `dateComponents`, this PR introduces a conditional branch. Since `dayOffset` is set manually via `qq`, `q1`, and `q2` keyword inputs, I assign a value greater than 2 (using 999 as a placeholder). This triggers the new branch, which sets the reminder date to the next Monday using the native `calendar.nextDate` function.

The following screenshots shows my updated setup:

1. Adding the new keyword input `qm` (`m` stands for Monday)
<img width="450" height="581" alt="image" src="https://github.com/user-attachments/assets/bc240840-1cf3-4139-80db-3b6b2887997a" />

2. Assign value 999 to `dayOffset` variable
<img width="1408" height="1276" alt="image" src="https://github.com/user-attachments/assets/5d8c675f-19ea-43a0-8e71-e5f7d02c43b7" />



## AI usage disclosure
<!-- If you used AI beyond simple autocomplete, describe how. 
AI-assisted code is not discouraged if it has been properly reviewed; 
this disclosure is for transparency. -->
Code are generated by ChatGPT 5.0 as I am not fluent in Swift. But I have used it in my personal workflow, updated the original 3.7.2 version. It has been tested and worked seamlessly as shown in the previous screenshots.

## Checklist
- [x] Variable names follow `camelCase` convention.
- [x] All AI-generated code has been reviewed by a human.
- [ ] Documentation (`README.md` and internal workflow docs) has been updated
  for any new or modified functionality. _(Not yet. Will update once the core functionality is agreed and PR gets approved.)_
